### PR TITLE
Fix running on Elixir 1.5/OTP 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: elixir
-elixir:
-  - 1.4.0
-otp_release:
-  - 19.0
+matrix:
+  include:
+    - otp_release: 19.0
+      elixir: 1.4
+    - otp_release: 20.0
+      elixir: 1.5
 env:
   - MIX_ENV=test
 script:

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ExTrello.Mixfile do
 
   defp deps do
     [
-      {:oauther, "~> 1.0"},
+      {:oauther, "~> 1.1"},
       {:poison, "~> 3.0"},
       {:httpoison, "~> 0.11"},
       {:ex_doc, ">= 0.0.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -14,6 +14,6 @@
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "oauther": {:hex, :oauther, "1.0.2", "c2a8476649f3def353db4d38aa498d1313a21e2dd36958ac74f6ee80ef374620", [:mix], []},
+  "oauther": {:hex, :oauther, "1.1.0", "c9a56e200507ce64e069f5273143db0cddd7904cd5d1fe46920388a48f22441b", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
Oauther previously depended on the deprecated (and now removed) `:crypto.rand_bytes/1`, this is fixed in the [latest release](https://github.com/lexmag/oauther/commit/6bda4da5701642ae5d8cd40d04741ba1ad8aef0c).

This pull requests updates oauther to the latest version and starts running travis tests towards the latest elixir and otp releases.